### PR TITLE
[JR-AVL-987] Adicionado opção de token como autenticação

### DIFF
--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,7 +101,7 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raised_without_authentication
+      raise(SecretError, 'API secret not configured') if current_authentication.nil?
 
       params_with_authentication = params.merge(current_authentication)
       query = URI.encode_www_form(params_with_authentication)
@@ -121,12 +121,6 @@ module ConvertApi
       end
 
       data
-    end
-
-    def raised_without_authentication
-      return unless current_authentication.nil?
-
-      raise(SecretError, 'API secret not configured')
     end
 
     def current_authentication

--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,10 +101,10 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raise(TokenError, 'Token not configured') if config.token.nil?
+      raised_without_authentication
 
-      params_with_token = params.merge(Token: config.token)
-      query = URI.encode_www_form(params_with_token)
+      params_with_authentication = params.merge(current_authentication)
+      query = URI.encode_www_form(params_with_authentication)
 
       base_uri.path + path + '?' + query
     end
@@ -121,6 +121,19 @@ module ConvertApi
       end
 
       data
+    end
+
+    def raised_without_authentication
+      return unless current_authentication.nil?
+
+      raise(SecretError, 'API secret not configured')
+    end
+
+    def current_authentication
+      return { Token: config.token } unless config.token.nil?
+      return { Secret: config.api_secret } unless config.api_secret.nil?
+
+      nil
     end
 
     def base_uri

--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,7 +101,7 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raise(SecretError, 'API secret not configured') if authentication.nil?
+      raise(AuthenticationError, 'API secret or Token not configured') if authentication.nil?
 
       params_with_authentication = params.merge(authentication)
       query = URI.encode_www_form(params_with_authentication)

--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,9 +101,9 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raise(SecretError, 'API secret not configured') if current_authentication.nil?
+      raise(SecretError, 'API secret not configured') if authentication.nil?
 
-      params_with_authentication = params.merge(current_authentication)
+      params_with_authentication = params.merge(authentication)
       query = URI.encode_www_form(params_with_authentication)
 
       base_uri.path + path + '?' + query
@@ -123,7 +123,7 @@ module ConvertApi
       data
     end
 
-    def current_authentication
+    def authentication
       return { Token: config.token } unless config.token.nil?
       return { Secret: config.api_secret } unless config.api_secret.nil?
 

--- a/lib/convert_api/client.rb
+++ b/lib/convert_api/client.rb
@@ -101,10 +101,10 @@ module ConvertApi
     end
 
     def request_uri(path, params = {})
-      raise(SecretError, 'API secret not configured') if config.api_secret.nil?
+      raise(TokenError, 'Token not configured') if config.token.nil?
 
-      params_with_secret = params.merge(Secret: config.api_secret)
-      query = URI.encode_www_form(params_with_secret)
+      params_with_token = params.merge(Token: config.token)
+      query = URI.encode_www_form(params_with_token)
 
       base_uri.path + path + '?' + query
     end

--- a/lib/convert_api/configuration.rb
+++ b/lib/convert_api/configuration.rb
@@ -1,6 +1,7 @@
 module ConvertApi
   class Configuration
     attr_accessor :api_secret
+    attr_accessor :token
     attr_accessor :base_uri
     attr_accessor :connect_timeout
     attr_accessor :read_timeout

--- a/lib/convert_api/errors.rb
+++ b/lib/convert_api/errors.rb
@@ -1,7 +1,6 @@
 module ConvertApi
   class Error < StandardError; end
-  class SecretError < Error; end
-  class TokenError < Error; end
+  class AuthenticationError < Error; end
   class FileNameError < Error; end
   class TimeoutError < Error; end
   class ConnectionFailed < Error; end

--- a/lib/convert_api/errors.rb
+++ b/lib/convert_api/errors.rb
@@ -1,6 +1,7 @@
 module ConvertApi
   class Error < StandardError; end
   class SecretError < Error; end
+  class TokenError < Error; end
   class FileNameError < Error; end
   class TimeoutError < Error; end
   class ConnectionFailed < Error; end

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe ConvertApi do
       it_behaves_like 'successful conversion'
     end
 
-    context 'when token is not set' do
-      before { ConvertApi.config.token = nil }
+    context 'when secret is not set' do
+      before { ConvertApi.config.api_secret = nil }
 
       it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
+        expect { subject }.to raise_error(ConvertApi::SecretError, /not configured/)
       end
     end
 

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe ConvertApi do
       it_behaves_like 'successful conversion'
     end
 
-    context 'when secret is not set' do
-      before { ConvertApi.config.api_secret = nil }
+    context 'when token is not set' do
+      before { ConvertApi.config.token = nil }
 
       it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::SecretError, /not configured/)
+        expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
       end
     end
 

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -92,18 +92,23 @@ RSpec.describe ConvertApi do
       it_behaves_like 'successful conversion'
     end
 
-    context 'when token is not set' do
-      before { described_class.config.token = nil }
+    context 'when has error' do
+      it 'raises error without secret or token' do
+        described_class.config.api_secret = nil
+        described_class.config.token = nil
 
-      it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
+        expect { subject }.to raise_error(ConvertApi::AuthenticationError, /not configured/)
       end
-    end
 
-    context 'with invalid token' do
-      before { described_class.config.token = 'invalid' }
+      it 'with invalid secret' do
+        described_class.config.api_secret = 'invalid'
 
-      it 'raises error' do
+        expect { subject }.to raise_error(ConvertApi::ClientError)
+      end
+
+      it 'with invalid token' do
+        described_class.config.token = 'invalid'
+
         expect { subject }.to raise_error(ConvertApi::ClientError)
       end
     end

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -10,15 +10,18 @@ RSpec.describe ConvertApi do
 
   describe '.configure' do
     let(:api_secret) { 'test_secret' }
+    let(:token) { 'test_token' }
     let(:conversion_timeout) { 20 }
 
     it 'configures' do
       described_class.configure do |config|
         config.api_secret = api_secret
+        config.token = token
         config.conversion_timeout = conversion_timeout
       end
 
       expect(described_class.config.api_secret).to eq(api_secret)
+      expect(described_class.config.token).to eq(token)
       expect(described_class.config.conversion_timeout).to eq(conversion_timeout)
     end
   end
@@ -89,11 +92,11 @@ RSpec.describe ConvertApi do
       it_behaves_like 'successful conversion'
     end
 
-    context 'when secret is not set' do
-      before { ConvertApi.config.api_secret = nil }
+    context 'when token is not set' do
+      before { ConvertApi.config.token = nil }
 
       it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::SecretError, /not configured/)
+        expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
       end
     end
 

--- a/spec/convert_api_spec.rb
+++ b/spec/convert_api_spec.rb
@@ -93,18 +93,18 @@ RSpec.describe ConvertApi do
     end
 
     context 'when token is not set' do
-      before { ConvertApi.config.token = nil }
+      before { described_class.config.token = nil }
 
       it 'raises error' do
         expect { subject }.to raise_error(ConvertApi::TokenError, /not configured/)
       end
     end
 
-    context 'with invalid secret' do
-      before { ConvertApi.config.api_secret = 'invalid' }
+    context 'with invalid token' do
+      before { described_class.config.token = 'invalid' }
 
       it 'raises error' do
-        expect { subject }.to raise_error(ConvertApi::ClientError, /bad secret/)
+        expect { subject }.to raise_error(ConvertApi::ClientError)
       end
     end
 


### PR DESCRIPTION
### Descrição

Atualmente na utilização da `gem convert_api`, só temos a opção de se autenticar utilizando a `api_secret`, porém isso faz com que tenhamos uma unica `secret`, para todos os ambientes (`dev`, `staging`, `sandbox` e `prod`), o que é ruim.

A ideia do PR, é ajustar a autenticação fornecida pela gem, para conseguirmos nos autenticar com o `token` e não via `api_secret`, dessa forma, cada ambiente terá sua autenticação;

### Issue tracker

Card do [Jira](https://clicksign.atlassian.net/browse/AVL-987).

### Code Review

Como fazer o Code Review:

[CONTRIBUTING.md](https://github.com/clicksign/.github/blob/8d623c886c2da0266d108d5fa21cf01a1c82cbc0/CONTRIBUTING.md)

### Checklist para poder mergear

- [x] O código do PR inclui (ou já possui) testes para o código nele
- [x] Os checks de linters estão passando
- [x] Os checks de testes estão passando
